### PR TITLE
Fix API target and GetById path

### DIFF
--- a/SWapi-CSharp/Repository.cs
+++ b/SWapi-CSharp/Repository.cs
@@ -30,7 +30,7 @@ namespace StarWarsApiCSharp
         /// <summary>
         /// The default API URL from where entities are downloaded.
         /// </summary>
-        private const string Api = "http://swapi.co/api/";
+        private const string Api = "https://swapi.dev/api/";
 
         /// <summary>
         /// The default page.
@@ -64,7 +64,7 @@ namespace StarWarsApiCSharp
         private T entity;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Repository{T}" /> class. 
+        /// Initializes a new instance of the <see cref="Repository{T}" /> class.
         /// Uses the default data service and URL for gather data.
         /// </summary>
         public Repository()
@@ -122,7 +122,7 @@ namespace StarWarsApiCSharp
         {
             // TODO: override-able GetPath Method ??
             // TODO: separate UrlBuilderClass
-            string url = this.urlData + this.entity.GetPath() + id;
+            string url = $"{this.urlData}{this.entity.GetPath()}{id}/";
             string jsonResponse = this.dataService.GetDataResult(url);
             if (jsonResponse == null)
             {

--- a/SWapi-CSharp/SWapi-CSharp.csproj
+++ b/SWapi-CSharp/SWapi-CSharp.csproj
@@ -38,9 +38,8 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\starwars-dotnet-rest\StarWarsDotnetRest\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/SWapi-CSharp/packages.config
+++ b/SWapi-CSharp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Was using this and found that since the API has moved, it also updated so that `/api/people/1` no longer works, you need `/api/people/1/`, so I've updated those.